### PR TITLE
Sort tool results for a cleaner UI experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See the [Indicator Search setup guide](docs/setup.md) and [menu options](docs/me
   "processing_time": 13.17,
   "results": [
     {
-      "site": "tweetfeed.live",
+      "tool": "tweetfeed.live",
       "results": {
         "date": "2023-07-19 13:33:54",
         "user": "CarlyGriggs13",
@@ -95,7 +95,7 @@ See the [Indicator Search setup guide](docs/setup.md) and [menu options](docs/me
       }
     },
     {
-      "site": "virustotal_domain",
+      "tool": "virustotal_domain",
       "results": {
         "harmless": 60,
         "malicious": 5,
@@ -116,7 +116,7 @@ See the [Indicator Search setup guide](docs/setup.md) and [menu options](docs/me
       }
     },
     {
-      "site": "virustotal_url",
+      "tool": "virustotal_url",
       "results": {
         "harmless": 63,
         "malicious": 6,
@@ -141,13 +141,13 @@ See the [Indicator Search setup guide](docs/setup.md) and [menu options](docs/me
       }
     },
     {
-      "site": "url_void",
+      "tool": "url_void",
       "results": {
         "error": "No results found"
       }
     },
     {
-      "site": "urlscan.io",
+      "tool": "urlscan.io",
       "results": {
         "last_scan_guid": "7e27ee56-5caa-4227-841a-1121cf65b692",
         "last_scan_url": "https://urlscan.io/result/7e27ee56-5caa-4227-841a-1121cf65b692/",
@@ -156,19 +156,19 @@ See the [Indicator Search setup guide](docs/setup.md) and [menu options](docs/me
       }
     },
     {
-      "site": "inquest_labs",
+      "tool": "inquest_labs",
       "results": {
         "error": "No results found"
       }
     },
     {
-      "site": "maltiverse",
+      "tool": "maltiverse",
       "results": {
         "error": "No results found"
       }
     },
     {
-      "site": "wayback_machine",
+      "tool": "wayback_machine",
       "results": {
         "error": "No results found"
       }

--- a/app/osint/_enrichments.py
+++ b/app/osint/_enrichments.py
@@ -38,22 +38,22 @@ def enrichments_handler(indicator):
 
 
 def geo_data(indicator):
-    results = {}
-    for site in indicator.results if indicator.results else []:
-        if site.get("site") == "ipinfo.io":
-            if site.get("results").get("geolocation"):
-                geo = site.get("results").get("geolocation")
+    enrichment = {}
+    for result in indicator.results if indicator.results else []:
+        if result.get("tool") == "ipinfo.io":
+            if result.get("results").get("geolocation"):
+                geo = result.get("results").get("geolocation")
                 geo = geo.split(",")
-                results.update({"geo_data": [geo[0], geo[1]]})
-    return results
+                enrichment.update({"geo_data": [geo[0], geo[1]]})
+    return enrichment
 
 
 def urlscan(indicator):
-    results = {}
-    for site in indicator.results if indicator.results else []:
-        if site.get("site") == "urlscan.io":
-            if site.get("results").get("last_scan_screenshot"):
+    enrichment = {}
+    for result in indicator.results if indicator.results else []:
+        if result.get("tool") == "urlscan.io":
+            if result.get("results").get("last_scan_screenshot"):
                 # fmt: off
-                results.update({"last_scan_screenshot": site.get("results").get("last_scan_screenshot")})
+                enrichment.update({"last_scan_screenshot": result.get("results").get("last_scan_screenshot")})
                 # fmt: on
-    return results
+    return enrichment

--- a/app/osint/_handler.py
+++ b/app/osint/_handler.py
@@ -223,7 +223,7 @@ def new_indicator_handler(indicator, user, db: Session):
         indicator.complete = True
         indicator.results = (
             {
-                "site": "Error",
+                "tool": "Error",
                 "results": {"error": str(e)},
             },
         )

--- a/app/osint/_handler.py
+++ b/app/osint/_handler.py
@@ -5,6 +5,7 @@ from . import tools, enrichments_handler, tagging_handler, links_handler
 from .. import notifications
 from ..models import Iocs
 from sqlalchemy.orm import Session
+from .utils import sort_results
 
 
 def new_indicator_handler(indicator, user, db: Session):
@@ -139,10 +140,12 @@ def new_indicator_handler(indicator, user, db: Session):
             indicator.results += tools.whatsmybrowser_ua(indicator)
         # fmt: on
 
+        # Wait for feedlist thread to finish
         if threads_to_wait_for:
             for thread in threads_to_wait_for:
                 thread.join()
 
+        # Remove results that have no data or tools that did not have an API key set
         for each in indicator.results:
             keys_to_remove = []
             for key, value in each["results"].items():
@@ -155,6 +158,9 @@ def new_indicator_handler(indicator, user, db: Session):
 
             if not each["results"]:
                 each["results"] = {"error": "No results found"}
+
+        # Sort results based on if the tool had results or not
+        indicator.results = sorted(indicator.results, key=sort_results)
 
         notifications.console_output(
             "OSINT Scan complete",

--- a/app/osint/_tagging.py
+++ b/app/osint/_tagging.py
@@ -65,24 +65,24 @@ def feedlist_results(indicator):
 
 def geo_data(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
+    for result in indicator.results if indicator.results else []:
         # fmt: off
-        if site.get("site") == "ip_whois":
-            tags.update({"country": site.get("results").get("country")})
+        if result.get("tool") == "ip_whois":
+            tags.update({"country": result.get("results").get("country")})
         
-        if site.get("site") == "ip_quality_score":
-            if site.get("results").get("mobile"):
-                tags.update({"mobile": site.get("results").get("mobile")})
+        if result.get("tool") == "ip_quality_score":
+            if result.get("results").get("mobile"):
+                tags.update({"mobile": result.get("results").get("mobile")})
             
-            if site.get("results").get("tor"):
-                tags.update({"tor": site.get("results").get("tor")})
+            if result.get("results").get("tor"):
+                tags.update({"tor": result.get("results").get("tor")})
             
-            if site.get("results").get("proxy"):
-                tags.update({"proxy": site.get("results").get("proxy")})
+            if result.get("results").get("proxy"):
+                tags.update({"proxy": result.get("results").get("proxy")})
                 
-            if site.get("results").get("connection_type"):
-                if not site.get("results").get("connection_type") == "Premium required.":
-                    tags.update({"connection_type": site.get("results").get("connection_type")})
+            if result.get("results").get("connection_type"):
+                if not result.get("results").get("connection_type") == "Premium required.":
+                    tags.update({"connection_type": result.get("results").get("connection_type")})
 
         # fmt: on
     return tags
@@ -90,20 +90,20 @@ def geo_data(indicator):
 
 def virustotal(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
+    for result in indicator.results if indicator.results else []:
         # fmt: off
-        if site.get("site") == "virustotal_hash":
-            if site.get("results").get("suggested_threat_label"):
-                tags.update({"signature": site.get("results").get("suggested_threat_label")})
+        if result.get("tool") == "virustotal_hash":
+            if result.get("results").get("suggested_threat_label"):
+                tags.update({"signature": result.get("results").get("suggested_threat_label")})
             
-            if site.get("results").get("popular_threat_category"):
-                tags.update({"category": site.get("results").get("popular_threat_category")})
+            if result.get("results").get("popular_threat_category"):
+                tags.update({"category": result.get("results").get("popular_threat_category")})
 
-        if site.get("site") in ["virustotal_url", "virustotal_hash", "virustotal_domain", "virustotal_ip"]: 
-            malicious_hits = site.get("results").get("malicious", 0)
-            undetected_hits = site.get("results").get("undetected", 0)
-            suspicious_hits = site.get("results").get("suspicious", 0)
-            harmless_hits = site.get("results").get("harmless", 0)
+        if result.get("tool") in ["virustotal_url", "virustotal_hash", "virustotal_domain", "virustotal_ip"]: 
+            malicious_hits = result.get("results").get("malicious", 0)
+            undetected_hits = result.get("results").get("undetected", 0)
+            suspicious_hits = result.get("results").get("suspicious", 0)
+            harmless_hits = result.get("results").get("harmless", 0)
             total_hits = int(malicious_hits) + int(undetected_hits) + int(suspicious_hits) + int(harmless_hits)
 
             if malicious_hits:
@@ -112,9 +112,9 @@ def virustotal(indicator):
                     tags.update({"suspicious": True})
                 if malicious_hits >= 10:
                     tags.update({"malicious": True})
-            if site.get("results").get("creation_date"):
+            if result.get("results").get("creation_date"):
                 # Parse the input time string into a datetime object
-                date_object = datetime.strptime(site.get("results").get("creation_date"), "%a %b %d %H:%M:%S %Y")
+                date_object = datetime.strptime(result.get("results").get("creation_date"), "%a %b %d %H:%M:%S %Y")
                 # Calculate the current date
                 current_date = datetime.now()
                 # Calculate the date 3 months ago from the current date
@@ -128,18 +128,20 @@ def virustotal(indicator):
 
 def tweetfeed(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
-        if site.get("site") == "tweetfeed.live" and site.get("results").get("value"):
+    for result in indicator.results if indicator.results else []:
+        if result.get("tool") == "tweetfeed.live" and result.get("results").get(
+            "value"
+        ):
             tags.update({"tweetfeed_match": True})
     return tags
 
 
 def greynoise(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
+    for result in indicator.results if indicator.results else []:
         if (
-            site.get("site") == "greynoise_community"
-            and site.get("results").get("classification", "") == "malicious"
+            result.get("tool") == "greynoise_community"
+            and result.get("results").get("classification", "") == "malicious"
         ):
             tags.update({"malicious": True})
     return tags
@@ -147,10 +149,10 @@ def greynoise(indicator):
 
 def urlscan(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
+    for result in indicator.results if indicator.results else []:
         if (
-            site.get("site") == "urlscan.io"
-            and site.get("results").get("malicious", "") == "malicious"
+            result.get("tool") == "urlscan.io"
+            and result.get("results").get("malicious", "") == "malicious"
         ):
             tags.update({"malicious": True})
     return tags
@@ -158,18 +160,18 @@ def urlscan(indicator):
 
 def known_binaries(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
-        if site.get("site") in ["circl.lu", "echo_trail"] and site.get("results").get(
-            "file_name", ""
-        ):
+    for result in indicator.results if indicator.results else []:
+        if result.get("tool") in ["circl.lu", "echo_trail"] and result.get(
+            "results"
+        ).get("file_name", ""):
             tags.update({"known_binary": True})
     return tags
 
 
 def breach_directory(indicator):
     tags = {}
-    for site in indicator.results if indicator.results else []:
-        if site.get("site") == "breach_directory":
-            if site.get("results").get("found"):
+    for result in indicator.results if indicator.results else []:
+        if result.get("tool") == "breach_directory":
+            if result.get("results").get("found"):
                 tags.update({"data_breach": True})
     return tags

--- a/app/osint/tools.py
+++ b/app/osint/tools.py
@@ -124,7 +124,7 @@ def ipinfoio(indicator):
         return (
             # fmt: off
             {
-                "site": "ipinfo.io",
+                "tool": "ipinfo.io",
                 "results": {
                     "city": response.json().get("city"),
                     "region": response.json().get("region"),
@@ -145,7 +145,7 @@ def search_ipwhois(indicator):
         obj = ipwhois.IPWhois(indicator.indicator)
         return (
             {
-                "site": "ip_whois",
+                "tool": "ip_whois",
                 "results": {
                     "asn_number": obj.lookup_rws().get("asn"),
                     "asn_registry": obj.lookup_rws().get("asn_registry"),
@@ -184,7 +184,7 @@ def ipqualityscore(indicator):
         return (
             # fmt: off
                 {
-                    "site": "ip_quality_score",
+                    "tool": "ip_quality_score",
                     "results": {
                         "isp": response.json().get("ISP", ""),
                         "organization": response.json().get("organization", ""),
@@ -232,7 +232,7 @@ def virustotal_ip(indicator):
         return (
             # fmt: off
                 {
-                    "site": "virustotal_ip",
+                    "tool": "virustotal_ip",
                     "results": {
                         "last analysis date": datetime.datetime.fromtimestamp(response.json().get("data").get("attributes").get("last_analysis_date")).strftime('%c') if response.json().get("data").get("attributes").get("last_analysis_date") else "",
                         "harmless": response.json().get("data").get("attributes").get("last_analysis_stats", {}).get("harmless"),
@@ -280,7 +280,7 @@ def virustotal_domain(indicator):
         return (
             # fmt: off
                 {
-                    "site": "virustotal_domain",
+                    "tool": "virustotal_domain",
                     "results": {
                         "whois": response.json().get("data").get("attributes").get("whois"),
                         "creation_date": datetime.datetime.fromtimestamp(response.json().get("data").get("attributes").get("creation_date")).strftime('%c') if response.json().get("data").get("attributes").get("creation_date") else "",
@@ -342,7 +342,7 @@ def virustotal_url(indicator):
         return (
             # fmt: off
                 {
-                    "site": "virustotal_url",
+                    "tool": "virustotal_url",
                     "results": {
                         "harmless": response.json().get("data").get("attributes").get("last_analysis_stats", {}).get("harmless"),
                         "malicious": response.json().get("data").get("attributes").get("last_analysis_stats", {}).get("malicious"),
@@ -390,7 +390,7 @@ def virustotal_hash(indicator):
         return (
             # fmt: off
                 {
-                    "site": "virustotal_hash",
+                    "tool": "virustotal_hash",
                     "results": {
                         "harmless": response.json().get("data").get("attributes").get("last_analysis_stats", {}).get("harmless"),
                         "malicious": response.json().get("data").get("attributes").get("last_analysis_stats", {}).get("malicious"),
@@ -441,7 +441,7 @@ def greynoise_community(indicator):
         return (
             # fmt: off
                 {
-                    "site": "greynoise_community",
+                    "tool": "greynoise_community",
                     "results": {
                         "classification": response.json().get("classification"),
                         "noise": response.json().get("noise"),
@@ -478,7 +478,7 @@ def hacked_ip_threatlist(indicator):
         return (
             # fmt: off
                 {
-                    "site": "hacked_ip",
+                    "tool": "hacked_ip",
                     "results": {
                         "active_threatlists": results_list
                     },
@@ -540,7 +540,7 @@ def urlvoid(indicator):
             return (
                 # fmt: off
                     {
-                        "site": "url_void",
+                        "tool": "url_void",
                         "results": {
                             "dns_records": response.json().get("data", {}).get("report", {}).get("dns_records", {}).get("mx", {}).get("records", []),
                             "detections": response.json().get("data", {}).get("report", {}).get("domain_blacklist", {}).get("detections"),
@@ -570,7 +570,7 @@ def macvendors(indicator):
 
         return (
             {
-                "site": "mac_vendors",
+                "tool": "mac_vendors",
                 "results": {
                     "manufacturer": response.text,
                 },
@@ -595,7 +595,7 @@ def stopforumspam_email(indicator):
         return (
             # fmt: off
                 {
-                    "site": "stop_forum_spam_email",
+                    "tool": "stop_forum_spam_email",
                     "results": {
                         "appears": results.get("response", {}).get("appears"),
                         "frequency": results.get("response", {}).get("frequency")
@@ -622,7 +622,7 @@ def stopforumspam_ip(indicator):
         return (
             # fmt: off
                 {
-                    "site": "stop_forum_spam_ip",
+                    "tool": "stop_forum_spam_ip",
                     "results": {
                         "appears": results.get("response", {}).get("appears"),
                         "frequency": results.get("response", {}).get("frequency")
@@ -655,7 +655,7 @@ def abuse_ipdb(indicator):
         # fmt: off
         return (
             {
-                "site": "abuseipdb",
+                "tool": "abuseipdb",
                 "results": {
                     "reports": response.json().get("data", {}).get("totalReports"),
                     "abuse_score": response.json().get("data", {}).get("abuseConfidenceScore"),
@@ -687,7 +687,7 @@ def emailrepio(indicator):
         return (
             # fmt: off
                 {
-                    "site": "emailrep.io",
+                    "tool": "emailrep.io",
                     "results": {
                         "reputation": response.json().get("reputation"),
                         "suspicious": response.json().get("suspicious"),
@@ -762,7 +762,7 @@ def tweetfeed_live(indicator):
 
         return (
             {
-                "site": "tweetfeed.live",
+                "tool": "tweetfeed.live",
                 "results": results,
             },
         )
@@ -803,7 +803,7 @@ def urlscanio(indicator):
         return (
             # fmt: off
                 {
-                    "site": "urlscan.io",
+                    "tool": "urlscan.io",
                     "results": {
                         "last_scan_guid": last_scan_response.json().get("task").get("uuid"),
                         "last_scan_url": last_scan_response.json().get("task").get("reportURL"),
@@ -845,7 +845,7 @@ def circl_lu(indicator):
         return (
             # fmt: off
                 {
-                    "site": "circl.lu",
+                    "tool": "circl.lu",
                     "results": {
                         "file_name": response.json().get("FileName"),
                         "file_size_kb": response.json().get("FileSize"),
@@ -875,7 +875,7 @@ def project_honeypot(indicator):
         return (
             # fmt: off
                 {
-                    "site": "project_honeypot",
+                    "tool": "project_honeypot",
                     "results": {
                         "days_since_last_activity": response.get("days_since_last_activity"),
                         "name": response.get("name"),
@@ -913,7 +913,7 @@ def echo_trail(indicator):
         return (
             # fmt: off
                 {
-                    "site": "echo_trail",
+                    "tool": "echo_trail",
                     "results": {
                         "file_name": response.json().get("filenames"),
                         "description": response.json().get("description"),
@@ -957,7 +957,7 @@ def hybrid_analysis(indicator):
         return (
             # fmt: off
                 {
-                    "site": "hybrid_analysis",
+                    "tool": "hybrid_analysis",
                     "results": {
                         "file_name": response.get("submissions")[0].get("filename"),
                         "type": response.get("type"),
@@ -1004,7 +1004,7 @@ def breach_directory(indicator):
         return (
             # fmt: off
                 {
-                    "site": "breach_directory",
+                    "tool": "breach_directory",
                     "results": {
                         "found": response.json().get("found", {}),
                         "frequency": response.json().get("result", [])
@@ -1030,7 +1030,7 @@ def shodan(indicator):
         return (
             # fmt: off
                 {
-                    "site": "shodan",
+                    "tool": "shodan",
                     "results": {
                         "hostnames": host.get("hostnames"),
                         "domains": host.get("domains"),
@@ -1071,7 +1071,7 @@ def malware_bazzar(indicator):
         return (
             # fmt: off
                 {
-                    "site": "malware_bazzar",
+                    "tool": "malware_bazzar",
                     "results": {
                         "file_type": response.json().get("data")[0].get("file_type"),
                         "signature": response.json().get("data")[0].get("signature"),
@@ -1138,7 +1138,7 @@ def inquestlabs(indicator):
         return (
             # fmt: off
                 {
-                    "site": "inquest_labs",
+                    "tool": "inquest_labs",
                     "results": {
                         "classification": response.json().get("data", [])[0].get("classification"),
                         "file_type": response.json().get("data", [])[0].get("file_type"),
@@ -1203,7 +1203,7 @@ def maltiverse(indicator):
         return (
             # fmt: off
                 {
-                    "site": "maltiverse",
+                    "tool": "maltiverse",
                     "results": {
                         "classification": result.get("classification", ""),
                         "blacklist": result.get("blacklist", []),
@@ -1232,7 +1232,7 @@ def numverify(indicator):
         return (
             # fmt: off
                 {
-                    "site": "numverify",
+                    "tool": "numverify",
                     "results": response.json()
                 },
             # fmt: on
@@ -1259,7 +1259,7 @@ def ipqualityscore_phone(indicator):
         return (
             # fmt: off
                 {
-                    "site": "ip_quality_score_phone",
+                    "tool": "ip_quality_score_phone",
                     "results": response.json()
                 },
             # fmt: on
@@ -1296,7 +1296,7 @@ def wayback_machine(indicator):
         return (
             # fmt: off
                 {
-                    "site": "wayback_machine",
+                    "tool": "wayback_machine",
                     "results": response.json().get("archived_snapshots", {}).get("closest")
                 },
             # fmt: on
@@ -1322,7 +1322,7 @@ def kickbox_disposible_email(indicator):
         return (
             # fmt: off
                 {
-                    "site": "kickbox_disposible_email",
+                    "tool": "kickbox_disposible_email",
                     "results": response.json().get("disposable", {})
                 },
             # fmt: on
@@ -1357,7 +1357,7 @@ def whatsmybrowser_ua(indicator):
         return (
             # fmt: off
                 {
-                    "site": "whatsmybrowser_ua",
+                    "tool": "whatsmybrowser_ua",
                     "results": {
                         "is_abusive": response.json().get("parse", {}).get("is_abusive"),
                         "simple_software_string": response.json().get("parse", {}).get("simple_software_string"),
@@ -1398,7 +1398,7 @@ def shimon(indicator):
         return (
             # fmt: off
                 {
-                    "site": "shimon",
+                    "tool": "shimon",
                     "results": response.json()
                 },
             # fmt: on

--- a/app/osint/utils.py
+++ b/app/osint/utils.py
@@ -149,3 +149,13 @@ def convert_url_to_fqdn(url):
         return domain_match.group(1)
     else:
         raise Exception("Invalid URL")
+
+
+def sort_results(item):
+    """This function is used to sort indicator.results. It places items with results at the top and items with "No results found" at the bottom. The tools will be sorted alphabetically within each group."""
+    if "error" in item["results"] and item["results"]["error"] == "No results found":
+        # Place sites with "No results found" at the bottom
+        return (float("inf"), item["tool"])
+    else:
+        # Place sites with results at the top
+        return (float("-inf"), item["tool"])

--- a/app/osint/utils.py
+++ b/app/osint/utils.py
@@ -81,7 +81,7 @@ def get_type(indicator):
 def no_results_found(tool_name):
     return (
         {
-            "site": tool_name,
+            "tool": tool_name,
             "results": {"error": "No results found"},
         },
     )
@@ -90,7 +90,7 @@ def no_results_found(tool_name):
 def failed_to_run(tool_name, error):
     return (
         {
-            "site": tool_name,
+            "tool": tool_name,
             "results": {"error": f"{tool_name} failed to run: {str(error)}"},
         },
     )
@@ -99,7 +99,7 @@ def failed_to_run(tool_name, error):
 def status_code_error(tool_name, status_code, reason):
     return (
         {
-            "site": tool_name,
+            "tool": tool_name,
             "results": {"error": f"{tool_name} failed to run: {status_code} {reason}"},
         },
     )
@@ -154,8 +154,8 @@ def convert_url_to_fqdn(url):
 def sort_results(item):
     """This function is used to sort indicator.results. It places items with results at the top and items with "No results found" at the bottom. The tools will be sorted alphabetically within each group."""
     if "error" in item["results"] and item["results"]["error"] == "No results found":
-        # Place sites with "No results found" at the bottom
+        # Place tools with "No results found" at the bottom
         return (float("inf"), item["tool"])
     else:
-        # Place sites with results at the top
+        # Place tools with results at the top
         return (float("-inf"), item["tool"])

--- a/app/routers/web/templates/results/_links_and_notes.html
+++ b/app/routers/web/templates/results/_links_and_notes.html
@@ -84,7 +84,7 @@
           <div class="ui list">
             {% for result in indicator.results %}
             {% if not result.results.error %}
-            <div class="item">• <a href="#{{result.site}}">{{result.site|snakecase_to_title}}</a></div>
+            <div class="item">• <a href="#{{result.tool}}">{{result.tool|snakecase_to_title}}</a></div>
             {% endif %}
             {% endfor %}
           </div>

--- a/app/routers/web/templates/results/_results.html
+++ b/app/routers/web/templates/results/_results.html
@@ -57,13 +57,13 @@
   }
 </script>
 
-{%for site in indicator.results %}
+{%for tool in indicator.results %}
 
-{% if "is not set in .env file" in site.results.error %}
+{% if "is not set in .env file" in tool.results.error %}
 
-{% elif "No results found" in site.results.error %}
+{% elif "No results found" in tool.results.error %}
 <div class="ui segment">
-  <p class="ui small header"><i class="fa-solid fa-circle-xmark"></i> {{site.site|snakecase_to_title}}: No results found
+  <p class="ui small header"><i class="fa-solid fa-circle-xmark"></i> {{tool.tool|snakecase_to_title}}: No results found
   </p>
 </div>
 
@@ -74,13 +74,13 @@
   top: 0px;
   right:-3.5px; 
   width: 50px;
-  border-radius: 0px 4px 0px 4px;" onclick='CopyTextToClipboard("{{site.results}}", this)'><i
+  border-radius: 0px 4px 0px 4px;" onclick='CopyTextToClipboard("{{tool.results}}", this)'><i
       class="fa-solid fa-copy"></i></button>
   <p class="ui small header">
-    <i class="fa-solid fa-circle-check"></i> <a id="{{site.site}}"></a>{{site.site|snakecase_to_title}}</i>
+    <i class="fa-solid fa-circle-check"></i> <a id="{{tool.tool}}"></a>{{tool.tool|snakecase_to_title}}</i>
   </p>
   <div class="ui two column grid">
-    {% for key,value in site.results.items() %}
+    {% for key,value in tool.results.items() %}
     <div class="column" style="padding: 14px; word-wrap: break-word">
       <div class="ui raised fluid card">
         <div class="content">


### PR DESCRIPTION
Closes #31 and renames `indicator.results.site`  to `indicator.results.tool` to clean up verbiage found within the codebase.  